### PR TITLE
fix: 修复 MaxxCore 中的内存管理问题

### DIFF
--- a/Source/MaxxCore.cpp
+++ b/Source/MaxxCore.cpp
@@ -136,7 +136,11 @@ int MaxxCore::analyze(juce::File pre, juce::File post) {
 		}
 	}
 
-	delete[]arrTimePre, arrTimePost, arrFreqPre, arrFreqPost, mSoftenTmp;
+	delete[] arrTimePre;
+	delete[] arrTimePost;
+	delete[] arrFreqPre;
+	delete[] arrFreqPost;
+	delete[] mSoftenTmp;
 
 	mIsAnalyzed = true;
 	return 0;
@@ -289,7 +293,8 @@ int MaxxCore::processTrackCore(juce::File track, juce::File destInfo, bool useAv
 	writer->flush();
 	delete writer;
 	os.release();
-	delete[] arrTime, arrFreq;
+	delete[] arrTime;
+	delete[] arrFreq;
 	return 0;
 }
 

--- a/Source/MaxxCore.cpp
+++ b/Source/MaxxCore.cpp
@@ -221,6 +221,7 @@ int MaxxCore::processTrackCore(juce::File track, juce::File destInfo, bool useAv
 			qualId);
 	if (!writer)
 		return 12; // can't create writer
+	os.release(); // writer 已接管 stream 所有权
 
 	juce::AudioBuffer<float> buf;
 	juce::AudioBuffer<float> bufDest;
@@ -286,7 +287,6 @@ int MaxxCore::processTrackCore(juce::File track, juce::File destInfo, bool useAv
 	}
 	writer->flush();
 	delete writer;
-	os.release();
 	delete[] arrTime;
 	delete[] arrFreq;
 	return 0;

--- a/Source/MaxxCore.cpp
+++ b/Source/MaxxCore.cpp
@@ -60,14 +60,10 @@ int MaxxCore::analyze(juce::File pre, juce::File post) {
 	bufPre.setSize(2, mFftSize);
 	bufPost.setSize(2, mFftSize);
 
-	auto arrTimePre = new kiss_fft_scalar[mFftSize];
-	auto arrTimePost = new kiss_fft_scalar[mFftSize];
 	auto arrFreqPre = new kiss_fft_cpx[mFreqDomainSize];
 	auto arrFreqPost = new kiss_fft_cpx[mFreqDomainSize];
 
 	auto mSoftenTmp = new float[mFreqDomainSize];
-
-	bool failed = false;
 
 	for (int i = 0; i < 2; i++) {
 		memset(mAvgDatas[i].data(), 0, sizeof(float) * mFreqDomainSize);
@@ -136,8 +132,6 @@ int MaxxCore::analyze(juce::File pre, juce::File post) {
 		}
 	}
 
-	delete[] arrTimePre;
-	delete[] arrTimePost;
 	delete[] arrFreqPre;
 	delete[] arrFreqPost;
 	delete[] mSoftenTmp;


### PR DESCRIPTION
修复 delete[] 逗号运算符仅释放首个指针导致的内存泄漏
移除分配但从未使用的变量
修复 OutputStream 所有权管理导致的 double-free 风险