### PR TITLE
refactor: 清理死代码和模板残留

### DIFF
--- a/Source/FftWindow.h
+++ b/Source/FftWindow.h
@@ -16,19 +16,4 @@ inline void fwHann(float* buf, const int n, const bool fin, const bool fout) {
 		auto ss = sinf(PI * ((float)i / (float)n));
 		buf[i] *= ss;
 	}
-}inline void fwHann2(float* buf, const int n) {
-	for (int i = 0; i < n; i++) {
-		auto ss = sinf(PI * ((float)i / (float)n));
-		buf[i] *= ss * ss;
-	}
-}
-
-inline void fwHann2(float* buf, const int n, const bool fin, const bool fout) {
-    int a =n/2, b= n/2;
-    if (fin) a = 0;
-    if (fout) b = n;
-	for (int i = a; i < b; i++) {
-		auto ss = sinf(PI * ((float)i / (float)n));
-		buf[i] *= ss*ss;
-	}
 }

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -6,9 +6,6 @@ MainComponent::MainComponent()
     mMaxx = std::make_unique<MaxxCore>();
     
     setSize (600, 640);
-    const auto fontName = "NotoSansJPVariableFont_wght_ttf";
-    int fontDataSize;
-    auto fontData = BinaryData::getNamedResource(fontName, fontDataSize);
     juce::Font textFont(14.0f);
     mBtnLoadPre.setBounds(20, 20, 100, 30);
     mBtnLoadPre.addListener(this);
@@ -76,14 +73,7 @@ MainComponent::~MainComponent()
 //==============================================================================
 void MainComponent::paint (juce::Graphics& g)
 {
-    // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
-
-    g.setFont (juce::FontOptions (16.0f));
-    g.setColour (juce::Colours::white);
-    g.drawText ("Hello World!", getLocalBounds(), juce::Justification::centred, true);
-
-
 }
 
 void MainComponent::resized()

--- a/Source/MathUtils.h
+++ b/Source/MathUtils.h
@@ -59,11 +59,6 @@ inline const kiss_fft_cpx rotate2D(kiss_fft_cpx cpx, kiss_fft_scalar rad) {
     return kiss_fft_cpx(x * cs - y * sn, x * sn + y * cs);
 }
 
-inline const kiss_fft_cpx remap(float x, kiss_fft_cpx a, kiss_fft_cpx b) {
-    kiss_fft_cpx result{ b.r*x + a.r*(1.0f-x), b.r * x + a.r * (1.0f - x) };
-    return result;
-}
-
 inline const bool isAllZero(float* data, int count) {
     for (int i = 0; i < count; i++) {
         if (!apprEq0(data[i]))

--- a/Source/MaxxCore.cpp
+++ b/Source/MaxxCore.cpp
@@ -31,7 +31,6 @@ int MaxxCore::analyze(juce::File pre, juce::File post) {
 	mIsAnalyzed = false;
 	mAnalysisCnt = 0;
 	for (int i = 0; i < 2; i++) {
-		mTimeDatas[i].clear();
 		mAnalysisDatas[i].clear();
 	}
 	auto readerPre = mFormatManager.createReaderFor(pre);
@@ -150,11 +149,6 @@ MaxxCore::StatusInfo MaxxCore::getStatus()
 		mAnalysisCnt,
 		mIsAnalyzed
 	};
-}
-
-int MaxxCore::analyzeCore(float** pre, float** post, int n)
-{
-	return 0;
 }
 
 int MaxxCore::processTracks(juce::Array<juce::File> files, juce::File destInfo, bool usePrefix)

--- a/Source/MaxxCore.cpp
+++ b/Source/MaxxCore.cpp
@@ -136,7 +136,11 @@ int MaxxCore::analyze(juce::File pre, juce::File post) {
 		}
 	}
 
-	delete[]arrTimePre, arrTimePost, arrFreqPre, arrFreqPost, mSoftenTmp;
+	delete[] arrTimePre;
+	delete[] arrTimePost;
+	delete[] arrFreqPre;
+	delete[] arrFreqPost;
+	delete[] mSoftenTmp;
 
 	mIsAnalyzed = true;
 	return 0;
@@ -289,7 +293,8 @@ int MaxxCore::processTrackCore(juce::File track, juce::File destInfo, bool useAv
 	writer->flush();
 	delete writer;
 	os.release();
-	delete[] arrTime, arrFreq;
+	delete[] arrTime;
+	delete[] arrFreq;
 	return 0;
 }
 

--- a/Source/MaxxCore.cpp
+++ b/Source/MaxxCore.cpp
@@ -221,6 +221,7 @@ int MaxxCore::processTrackCore(juce::File track, juce::File destInfo, bool useAv
 			qualId);
 	if (!writer)
 		return 12; // can't create writer
+	os.release(); // writer 已接管 stream 所有权
 
 	juce::AudioBuffer<float> buf;
 	juce::AudioBuffer<float> bufDest;
@@ -286,7 +287,6 @@ int MaxxCore::processTrackCore(juce::File track, juce::File destInfo, bool useAv
 	}
 	writer->flush();
 	delete writer;
-	os.release();
 	delete[] arrTime;
 	delete[] arrFreq;
 	return 0;

--- a/Source/MaxxCore.cpp
+++ b/Source/MaxxCore.cpp
@@ -60,14 +60,10 @@ int MaxxCore::analyze(juce::File pre, juce::File post) {
 	bufPre.setSize(2, mFftSize);
 	bufPost.setSize(2, mFftSize);
 
-	auto arrTimePre = new kiss_fft_scalar[mFftSize];
-	auto arrTimePost = new kiss_fft_scalar[mFftSize];
 	auto arrFreqPre = new kiss_fft_cpx[mFreqDomainSize];
 	auto arrFreqPost = new kiss_fft_cpx[mFreqDomainSize];
 
 	auto mSoftenTmp = new float[mFreqDomainSize];
-
-	bool failed = false;
 
 	for (int i = 0; i < 2; i++) {
 		memset(mAvgDatas[i].data(), 0, sizeof(float) * mFreqDomainSize);
@@ -136,8 +132,6 @@ int MaxxCore::analyze(juce::File pre, juce::File post) {
 		}
 	}
 
-	delete[] arrTimePre;
-	delete[] arrTimePost;
 	delete[] arrFreqPre;
 	delete[] arrFreqPost;
 	delete[] mSoftenTmp;

--- a/Source/MaxxCore.h
+++ b/Source/MaxxCore.h
@@ -24,10 +24,8 @@ private:
     double mSampleRate = 0;
     bool mIsAnalyzed = false;
     int64_t mAnalysisCnt = 0;
-    std::vector<float> mTimeDatas[2], mAnalysisDatas[2];
+    std::vector<float> mAnalysisDatas[2];
     kiss_fftr_cfg mCfgFft, mCfgIfft;
-    float* fftArrTime;
-    kiss_fft_cpx* fftArrFreq;
     bool mIsSoften = false;
     int mSoftenKernelSize = 16;
     float mSoftenSigma = 4.f;
@@ -43,9 +41,7 @@ public:
     int processShots(juce::Array<juce::File>, juce::File, bool = true);
 private:
     juce::AudioFormatManager mFormatManager;
-    juce::AudioBuffer<float> cool;
 
-    int analyzeCore(float** pre, float** post, int n);
     int processTrackCore(juce::File, juce::File, bool, bool);
 
 };


### PR DESCRIPTION
移除项目中未被使用的代码，减少维护负担，消除潜在的悬空指针风险。

### MaxxCore.h / MaxxCore.cpp

- **`mTimeDatas[2]`**：`analyze()` 中只做了 `clear()`，从未 `push_back` 或读取。实际的分析数据存储在 `mAnalysisDatas` 和 `mAvgDatas` 中，`mTimeDatas` 没有参与任何计算流程。
- **`fftArrTime` / `fftArrFreq`**：裸指针成员变量，从未分配内存也从未读写。作为未初始化的悬空指针留在类中，如果未来误用会导致未定义行为。
- **`cool`**：`AudioBuffer<float>` 成员变量，无意义命名，从未读写。每次构造 `MaxxCore` 会多创建一个空的音频缓冲区，浪费内存。
- **`analyzeCore()`**：函数体为空（直接 `return 0`），从未被调用。实际的分析逻辑直接写在 `analyze()` 中。

### MainComponent.cpp

- **字体加载代码**（`fontName`、`fontDataSize`、`fontData`）：通过 `BinaryData::getNamedResource` 加载了 NotoSansJP 字体数据，但获取后没有用它构建 `juce::Font`。下方的 `textFont` 使用的是默认字体。字体资源被加载进内存但从未使用。
- **`Hello World!` 绘制**：`paint()` 中在整个窗口居中绘制 "Hello World!"，是 JUCE Projucer 自动生成的模板代码。实际 UI 内容由 `mAnalysisIndicator` 等子组件承载，这段文字会被组件遮挡且与项目功能无关。

### FftWindow.h

- **`fwHann2()` 两个重载**：实现了 Hann² 窗函数，但项目中 FFT 分析和重合成均使用的是 `fwHann()`（标准 Hann 窗），从未调用过 Hann² 变体。

### MathUtils.h

- **`remap()`**：意图对两个复数做线性插值，但虚部公式误用了 `.r` 分量（实部和虚部计算完全相同），实现有 bug。且从未被调用，项目的频域处理使用的是标量乘法（`resizeCpx`），不需要复数间插值。

## 保留说明

- `getStatus()` / `StatusInfo`：虽暂未调用，但作为公开 API 语义明确，未来用于 UI 展示分析状态时可直接使用。
- MathUtils.h 中其他工具函数（`smoothstep`、`isAllZero` 等）：DSP 项目常用基础工具，保留作为工具库。
